### PR TITLE
Update driver capability and change float handling

### DIFF
--- a/Apps/Averaging Plus/AP-child.groovy
+++ b/Apps/Averaging Plus/AP-child.groovy
@@ -298,6 +298,7 @@ def averageHandler(evt) {
         numOfDev = 0
         state.low = false
         state.high = false
+        floatingPoint = false
         
         theDevices.each { it ->
             if(logEnable) log.debug "In averageHandler - working on ${it} - ${attrib}"
@@ -314,7 +315,9 @@ def averageHandler(evt) {
         if(totalNum == 0 || totalNum == null) {
             state.theAverage = 0
         } else {
-            state.theAverage = (totalNum / numOfDev).toDouble().round(1)
+            state.theAverage = floatingPoint
+                ? (totalNum / numOfDev).toDouble().round(1)
+                : (totalNum / numOfDev).toDouble().round()
         }
         
         todaysHigh = dataDevice.currentValue("todaysHigh")

--- a/Apps/Averaging Plus/AP-driver.groovy
+++ b/Apps/Averaging Plus/AP-driver.groovy
@@ -48,7 +48,8 @@ metadata {
         capability "Contact Sensor"
         capability "Motion Sensor"
         capability "Water Sensor"
-        
+        capability "IlluminanceMeasurement"
+
         command "clearData"
         command "virtualAverage", ["string"]
         command "todaysHigh", ["string"]


### PR DESCRIPTION
this adds IlluminanceMeasurement to the driver so ML can use it and only uses floating point numbers if any of the original values were also floating point (since ML can't handle floats).