### PR TITLE
ring keypad: add key brightness config, update state during exit delay

### DIFF
--- a/Drivers/Ring Alarm Keypad G2 Community/rakg2-driver.groovy
+++ b/Drivers/Ring Alarm Keypad G2 Community/rakg2-driver.groovy
@@ -77,7 +77,9 @@ metadata {
 @Field static Map configParams = [
         4: [input: [name: "configParam4", type: "enum", title: "Announcement Volume", description:"", defaultValue:7, options:[0:"0",1:"1",2:"2",3:"3",4:"4",5:"5",6:"6",7:"7",8:"8",9:"9",10:"10"]],parameterSize:1],
         5: [input: [name: "configParam5", type: "enum", title: "Keytone Volume", description:"", defaultValue:6, options:[0:"0",1:"1",2:"2",3:"3",4:"4",5:"5",6:"6",7:"7",8:"8",9:"9",10:"10"]],parameterSize:1],
-        6: [input: [name: "configParam6", type: "enum", title: "Siren Volume", description:"", defaultValue:10, options:[0:"0",1:"1",2:"2",3:"3",4:"4",5:"5",6:"6",7:"7",8:"8",9:"9",10:"10"]],parameterSize:1]
+        6: [input: [name: "configParam6", type: "enum", title: "Siren Volume", description:"", defaultValue:10, options:[0:"0",1:"1",2:"2",3:"3",4:"4",5:"5",6:"6",7:"7",8:"8",9:"9",10:"10"]],parameterSize:1],
+        12: [input: [name: "configParam12", type: "number", title: "Security Mode Brightness", description:"", defaultValue: 100, range:"0..100"],parameterSize:1],
+        13: [input: [name: "configParam13", type: "number", title: "Key Backlight Brightness", description:"", defaultValue: 100, range:"0..100"],parameterSize:1],
 ]
 @Field static Map armingStates = [
         0x00: [securityKeypadState: "armed night", hsmCmd: "armNight"],
@@ -222,6 +224,10 @@ void exitDelay(delay){
     if (logEnable) log.debug "exitDelay(${delay})"
     if (delay) {
         sendToDevice(zwave.indicatorV3.indicatorSet(indicatorCount:1, value: 0, indicatorValues:[[indicatorId:0x12, propertyId:7, value:delay.toInteger()]]).format())
+        // update state so that a disarm command during the exit delay resets the indicator lights
+        state.keypadStatus = "18"
+        type = state.code != "" ? "physical" : "digital" 
+        eventProcess(name: "securityKeypad", value: "exit delay", type: type, data: state.code)
     }
 }
 


### PR DESCRIPTION
1. Added preferences to configure keypad backlight brightness
2. Update state and securityKeypad attribute in `exitDelay` -- this addresses a bug, if the keypad was disarmed during the exit delay, the visual indicators for the delay timer would not be cleared as the code looks for `sk != "disarmed"`, but the state had not yet been updated to something different.